### PR TITLE
Add <limits> to fix compilation with GCC 11

### DIFF
--- a/src/os_driver.cpp
+++ b/src/os_driver.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <limits>
 #include <optional>
 #include <type_traits>
 #include <unordered_set>


### PR DESCRIPTION
Compiling with GCC 11 results in errors like
```bash
/build/rocm-dbgapi/src/ROCdbgapi-rocm-4.3.0/src/os_driver.cpp:579:38: error: ‘numeric_limits’ is not a member of ‘std’
  579 |   dbgapi_assert (queue_count <= std::numeric_limits<uint32_t>::max ());
      |                                      ^~~~~~~~~~~~~~
```
This is fixed by adding `#include <limits>` to `src/os_driver.cpp`.