### PR TITLE
use CMake's libdir instead of hardcoding it. Fixes #7

### DIFF
--- a/amd-dbgapi.pc.in
+++ b/amd-dbgapi.pc.in
@@ -1,6 +1,6 @@
 prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
-libdir=${prefix}/lib
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/include
 
 Name: amd-dbgapi


### PR DESCRIPTION
This uses CMake's detection of lib vs. lib64 when generating the pkgconfig file.