### PR TITLE
Use standard C types for 32 and 64 bit variables.

### DIFF
--- a/src/linux/kfd_ioctl.h
+++ b/src/linux/kfd_ioctl.h
@@ -23,8 +23,10 @@
 #ifndef KFD_IOCTL_H_INCLUDED
 #define KFD_IOCTL_H_INCLUDED
 
-#include <linux/types.h>
-#include <linux/ioctl.h>
+#include <stdint.h>
+typedef int32_t __s32;
+typedef uint32_t __u32;
+typedef uint64_t __u64;
 
 /*
  * - 1.1 - initial version

--- a/src/os_driver.cpp
+++ b/src/os_driver.cpp
@@ -1856,9 +1856,9 @@ std::string
 to_string (kfd_dbg_device_info_entry entry)
 {
   return string_printf (
-    "{ .exception_status=%#llx, .lds_base=%#llx, .lds_limit=%#llx, "
-    ".scratch_base=%#llx, .scratch_limit=%#llx, .gpuvm_base=%#llx, "
-    ".gpuvm_limit=%#llx, .gpu_id=%d, .location_id=%#x, .vendor_id=%#x, "
+    "{ .exception_status=%#" PRIx64 ", .lds_base=%#" PRIx64 ", .lds_limit=%#" PRIx64 ", "
+    ".scratch_base=%#" PRIx64 ", .scratch_limit=%#" PRIx64 ", .gpuvm_base=%#" PRIx64 ", "
+    ".gpuvm_limit=%#" PRIx64 ", .gpu_id=%d, .location_id=%#x, .vendor_id=%#x, "
     ".device_id=%#x, .fw_version=%d, .gfx_target_version=%#x, "
     ".simd_count=%d, .max_waves_per_simd=%d, .array_count=%d, "
     ".simd_arrays_per_engine=%d, .capability=%#x, .debug_prop=%#x }",
@@ -1895,7 +1895,7 @@ std::string
 to_string (os_runtime_info_t runtime_info)
 {
   return string_printf (
-    "{ .r_debug=%#llx, .runtime_state=%s, .ttmp_setup=%d }",
+    "{ .r_debug=%#" PRIx64 ", .runtime_state=%s, .ttmp_setup=%d }",
     runtime_info.r_debug,
     to_cstring (static_cast<os_runtime_state_t> (runtime_info.runtime_state)),
     runtime_info.ttmp_setup);
@@ -1928,10 +1928,10 @@ std::string
 to_string (os_queue_snapshot_entry_t snapshot)
 {
   return string_printf (
-    "{ .exception_status=%#llx, .ring_base_address=%#llx, "
-    ".write_pointer_address=%#llx, .read_pointer_address=%#llx, "
-    ".ctx_save_restore_address=%#llx, .queue_id=%d, .gpu_id=%d, "
-    ".ring_size=%d, .queue_type=%d }",
+    "{ .exception_status=%#" PRIx64 ", .ring_base_address=%#" PRIx64 ", "
+    ".write_pointer_address=%#" PRIx64 ", .read_pointer_address=%#" PRIx64 ", "
+    ".ctx_save_restore_address=%#" PRIx64 ", .queue_id=%" PRId32 ", .gpu_id=%" PRId32 ", "
+    ".ring_size=%" PRId32 ", .queue_type=%" PRId32 " }",
     snapshot.exception_status, snapshot.ring_base_address,
     snapshot.write_pointer_address, snapshot.read_pointer_address,
     snapshot.ctx_save_restore_address, snapshot.queue_id, snapshot.gpu_id,

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -804,7 +804,7 @@ aql_queue_t::update_waves ()
       if (control_stack_begin != control_stack_end)
         {
           log_info ("decoding %s's context save area #%u: "
-                    "ctrl_stk:[0x%llx..0x%llx[, wave_area:[0x%llx..0x%llx[",
+                    "ctrl_stk:[0x%" PRIx64 "..0x%" PRIx64 "[, wave_area:[0x%" PRIx64 "..0x%" PRIx64 "[",
                     to_cstring (id ()), xcc_id, control_stack_begin,
                     control_stack_end, wave_area_begin, wave_area_end);
 


### PR DESCRIPTION
This make the code build on 64 bit PowerPC.  It also ensure standard user space types are used instead of Linux specific types.  This was required to get the code to build on amd64, where __u64 is 'unsigned long long', while uint64_t is 'unsigned long' (both with sizeof() == 8), and PRIx64 expect the latter.

All formatting of 64 bit types are converted to use PRIxN style formatting statements.  Some 32 bit use is also converted, but did not try to track down every use as this do not affect PowerPC.  Also drop the <linux/ioctl.h> include, as it seem to be unused.

This addresses https://bugs.debian.org/1081303

Fixes #14.