### PR TITLE
Bump to 0.77.3 and document new gfx950 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Full documentation for AMD Debugger API is available at
 [rocm.docs.amd.com/rocdbgapi](https://rocm.docs.amd.com/projects/ROCdbgapi/en/latest/index.html).
 
+## rocm-dbgapi-0.77.3 for ROCm-6.5
+### Added
+- Support for the gfx950 architecture.
+
 ## rocm-dbgapi-0.77.2 for ROCm-6.4
 ### Added
 - Support for generic code object targets:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.77.2)
+project(amd-dbgapi VERSION 0.77.3)
 
 include(CheckIncludeFile)
 include(GNUInstallDirs)


### PR DESCRIPTION
The commit ae5cd1b85f9 "Add gfx950 architecture" added the gfx950 architecture, but forgot to add an entry in the changelog file.  This patch changes this, and increases the patch version number to reflect this change.

Change-Id: I1d098da1d20dee01deb877c88e21d071d3d5c397