### PR TITLE
src/queue: Pass cwsr_record to scratch_memory_region

### DIFF
--- a/src/architecture.cpp
+++ b/src/architecture.cpp
@@ -2535,10 +2535,9 @@ public:
   }
 
   std::pair<amd_dbgapi_size_t /* offset  */, amd_dbgapi_size_t /* size  */>
-  scratch_memory_region (const agent_t &agent,
-                         uint32_t compute_tmpring_size_register,
-                         uint32_t xcc_id, uint32_t shader_engine_id,
-                         uint32_t scoreboard_id) const override;
+  scratch_memory_region (
+    const agent_t &agent, uint32_t compute_tmpring_size_register,
+    const architecture_t::cwsr_record_t &cwsr_record) const override;
 };
 
 gfx9_architecture_t::gfx9_architecture_t (elf_amdgpu_machine_t e_machine,
@@ -3333,7 +3332,7 @@ gfx9_architecture_t::dispatch_packet_address (
 std::pair<amd_dbgapi_size_t /* offset  */, amd_dbgapi_size_t /* size  */>
 gfx9_architecture_t::scratch_memory_region (
   const agent_t &agent, uint32_t compute_tmpring_size_register,
-  uint32_t xcc_id, uint32_t shader_engine_id, uint32_t scoreboard_id) const
+  const architecture_t::cwsr_record_t &cwsr_record) const
 {
   /* Total size of allocated scratch memory in number of waves.  */
   amd_dbgapi_size_t waves
@@ -3347,7 +3346,8 @@ gfx9_architecture_t::scratch_memory_region (
   dbgapi_assert (shader_engine_count != 0);
 
   amd_dbgapi_size_t offset
-    = ((waves / shader_engine_count) * shader_engine_id + scoreboard_id)
+    = ((waves / shader_engine_count) * cwsr_record.shader_engine_id ()
+       + cwsr_record.scratch_scoreboard_id ())
       * wavesize;
 
   /* Make sure the number of waves is divisible by the number of shader
@@ -3364,7 +3364,8 @@ gfx9_architecture_t::scratch_memory_region (
 
   /* The scratch memory is evenly divided between all XCCs, so each XCC has its
      own scratch base.  */
-  amd_dbgapi_size_t xcc_scratch_base = waves * wavesize * xcc_id;
+  amd_dbgapi_size_t xcc_scratch_base
+    = waves * wavesize * cwsr_record.xcc_id ();
 
   return { xcc_scratch_base + offset, wavesize };
 }
@@ -5443,10 +5444,9 @@ public:
   const void *register_read_only_mask (amdgpu_regnum_t regnum) const override;
 
   std::pair<amd_dbgapi_size_t /* offset  */, amd_dbgapi_size_t /* size  */>
-  scratch_memory_region (const agent_t &agent,
-                         uint32_t compute_tmpring_size_register,
-                         uint32_t xcc_id, uint32_t shader_engine_id,
-                         uint32_t scoreboard_id) const override;
+  scratch_memory_region (
+    const agent_t &agent, uint32_t compute_tmpring_size_register,
+    const architecture_t::cwsr_record_t &cwsr_record) const override;
 
   bool can_halt_at_endpgm () const override { return true; }
   bool can_halt_at_sendmsg_dealloc_vgprs () const
@@ -5997,7 +5997,7 @@ gfx11_architecture_t::can_simulate (wave_t &wave,
 std::pair<amd_dbgapi_size_t /* offset  */, amd_dbgapi_size_t /* size  */>
 gfx11_architecture_t::scratch_memory_region (
   const agent_t &agent, uint32_t compute_tmpring_size_register,
-  uint32_t xcc_id, uint32_t shader_engine_id, uint32_t scoreboard_id) const
+  const architecture_t::cwsr_record_t &cwsr_record) const
 {
   /* Total size of allocated scratch memory in number of waves.  */
   amd_dbgapi_size_t waves
@@ -6007,8 +6007,9 @@ gfx11_architecture_t::scratch_memory_region (
     = utils::bit_extract (compute_tmpring_size_register, 12, 26) * 256;
 
   /* For gfx11, the number of waves is per shader engine instead of total.  */
-  amd_dbgapi_size_t offset
-    = (waves * shader_engine_id + scoreboard_id) * wavesize;
+  amd_dbgapi_size_t offset = (waves * cwsr_record.shader_engine_id ()
+                              + cwsr_record.scratch_scoreboard_id ())
+                             * wavesize;
 
   uint32_t shader_engine_count
     = agent.os_info ().shader_engine_count / agent.os_info ().xcc_count;
@@ -6016,7 +6017,7 @@ gfx11_architecture_t::scratch_memory_region (
   /* The scratch memory is evenly divided between all XCCs, so each XCC has its
      own scratch base.  */
   amd_dbgapi_size_t xcc_scratch_base
-    = waves * shader_engine_count * wavesize * xcc_id;
+    = waves * shader_engine_count * wavesize * cwsr_record.xcc_id ();
 
   return { xcc_scratch_base + offset, wavesize };
 }

--- a/src/architecture.h
+++ b/src/architecture.h
@@ -289,9 +289,7 @@ public:
                     amd_dbgapi_size_t /* size  */>
   scratch_memory_region (const agent_t &,
                          uint32_t compute_tmpring_size_register,
-                         uint32_t xcc_id, uint32_t shader_engine_id,
-                         uint32_t scoreboard_id) const
-    = 0;
+                         const cwsr_record_t &cwsr_record) const = 0;
 
   virtual bool
   is_address_space_supported (const address_space_t &address_space) const = 0;

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -182,8 +182,8 @@ public:
 
   std::pair<amd_dbgapi_global_address_t /* address */,
             amd_dbgapi_size_t /* size */>
-  scratch_memory_region (uint32_t xcc_id, uint32_t shader_engine_id,
-                         uint32_t scoreboard_id) const override;
+  scratch_memory_region (
+    const architecture_t::cwsr_record_t &cwsr_record) const override;
 
   size_t packet_size () const override { return aql_packet_size; };
 
@@ -860,11 +860,11 @@ aql_queue_t::update_waves ()
 
 std::pair<amd_dbgapi_global_address_t /* address */,
           amd_dbgapi_size_t /* size */>
-aql_queue_t::scratch_memory_region (uint32_t xcc_id, uint32_t shader_engine_id,
-                                    uint32_t scoreboard_id) const
+aql_queue_t::scratch_memory_region (
+  const architecture_t::cwsr_record_t &cwsr_record) const
 {
   auto [offset, size] = architecture ().scratch_memory_region (
-    agent (), m_compute_tmpring_size, xcc_id, shader_engine_id, scoreboard_id);
+    agent (), m_compute_tmpring_size, cwsr_record);
 
   return { m_scratch_backing_memory_address + offset, size };
 }

--- a/src/queue.h
+++ b/src/queue.h
@@ -205,8 +205,8 @@ public:
   /* Return the wave's scratch memory region (address and size).  */
   virtual std::pair<amd_dbgapi_global_address_t /* address */,
                     amd_dbgapi_size_t /* size */>
-  scratch_memory_region (uint32_t xcc_id, uint32_t shader_engine_id,
-                         uint32_t scoreboard_id) const = 0;
+  scratch_memory_region (
+    const architecture_t::cwsr_record_t &cwsr_record) const = 0;
 
   /* Return a pointer to device accessible memory containing the given
      instruction bytes.  */

--- a/src/wave.cpp
+++ b/src/wave.cpp
@@ -794,9 +794,8 @@ std::pair<amd_dbgapi_global_address_t /* address */,
           amd_dbgapi_size_t /* size */>
 wave_t::scratch_memory_region () const
 {
-  auto [address, size] = queue ().scratch_memory_region (
-    m_cwsr_record->xcc_id (), m_cwsr_record->shader_engine_id (),
-    m_cwsr_record->scratch_scoreboard_id ());
+  auto [address, size]
+    = queue ().scratch_memory_region (*m_cwsr_record.get ());
 
   /* On architectures with an architected flat_scratch register, check that the
      computed slot scratch address matches the content of the register.  */


### PR DESCRIPTION
This patch will make changes around scratch memory region computation easier in future patches.

Co-authored-by: Laurent Morichetti <laurent.morichetti@amd.com>

Change-Id: Idb2fb37e58da4713a139b747f71ef3704f0854e8