### PR TITLE
kernel_descriptor_t::is_at_kernel_entry: Make argument a agent_address_t

### DIFF
--- a/src/architecture.cpp
+++ b/src/architecture.cpp
@@ -232,7 +232,7 @@ protected:
       return address () + m_descriptor.kernel_code_entry_byte_offset;
     }
 
-    bool is_at_kernel_entry (global_address_t pc) const override
+    bool is_at_kernel_entry (agent_address_t pc) const override
     {
       /* There are 2 possible entry points to a kernel, one at offset 0x0 and
          the other at offset 0x100 from the kernel_code_entry address.  The

--- a/src/architecture.h
+++ b/src/architecture.h
@@ -176,7 +176,7 @@ public:
     virtual ~kernel_descriptor_t () = default;
 
     virtual global_address_t entry_address () const = 0;
-    virtual bool is_at_kernel_entry (global_address_t pc) const = 0;
+    virtual bool is_at_kernel_entry (agent_address_t pc) const = 0;
 
     global_address_t address () const { return m_address; }
     process_t &process () const { return m_process; }

--- a/src/queue.cpp
+++ b/src/queue.cpp
@@ -752,7 +752,7 @@ aql_queue_t::update_waves ()
                           seen by queue_t::update_waves before.  */
         && wave->state () == AMD_DBGAPI_WAVE_STATE_RUN
         && wave->dispatch ().kernel_descriptor ().is_at_kernel_entry (
-          global_address_t{wave->pc ()})
+          wave->pc ())
         && wave->is_halted ())
       {
         log_verbose ("%s is halted at launch", to_cstring (wave->id ()));

--- a/src/queue.h
+++ b/src/queue.h
@@ -161,7 +161,7 @@ protected:
       {
       }
       global_address_t entry_address () const override { return 0; }
-      bool is_at_kernel_entry (global_address_t /* pc  */) const override
+      bool is_at_kernel_entry (agent_address_t /* pc  */) const override
       {
         return false;
       }


### PR DESCRIPTION
Change the is_at_kernel_entry method to accept an agent_address_t, the effective type of a wave's PC.

Change-Id: I513a61c40d8662c9b48736bd3ca36633b48ab266