### PR TITLE
gfx12: Expose the SCHED_MODE register

### DIFF
--- a/src/architecture.cpp
+++ b/src/architecture.cpp
@@ -6348,6 +6348,8 @@ gfx12_architecture_t::gfx12_architecture_t (elf_amdgpu_machine_t e_machine,
                                   amdgpu_regnum_t::excp_flag_priv);
   system_registers.add_registers (amdgpu_regnum_t::excp_flag_user,
                                   amdgpu_regnum_t::excp_flag_user);
+  system_registers.add_registers (amdgpu_regnum_t::sched_mode,
+				  amdgpu_regnum_t::sched_mode);
 }
 
 std::optional<uint64_t>
@@ -6661,6 +6663,9 @@ gfx12_architecture_t::register_name (amdgpu_regnum_t regnum) const
     case amdgpu_regnum_t::scratch_base_hi:
       return "scratch_base_hi";
 
+    case amdgpu_regnum_t::sched_mode:
+      return "sched_mode";
+
     case amdgpu_regnum_t::trapsts:
       dbgapi_assert (false && "trapsts does not exist for gfx12");
       break;
@@ -6792,6 +6797,14 @@ gfx12_architecture_t::register_type (amdgpu_regnum_t regnum) const
     case amdgpu_regnum_t::scratch_base_hi:
       return "uint32_t";
 
+    case amdgpu_regnum_t::sched_mode:
+      return "flags32_t sched_mode {"
+             "  enum fp_round {"
+             "    NORMAL = 0,"
+             "    EXPERT = 2"
+             "  } DEP_MDOE @0-1;"
+             "}";
+
     case amdgpu_regnum_t::trapsts:
       dbgapi_assert (false && "trapsts does not exist in gfx12");
 
@@ -6812,6 +6825,7 @@ gfx12_architecture_t::register_size (amdgpu_regnum_t regnum) const
     case amdgpu_regnum_t::excp_flag_user:
     case amdgpu_regnum_t::scratch_base_lo:
     case amdgpu_regnum_t::scratch_base_hi:
+    case amdgpu_regnum_t::sched_mode:
       return sizeof (uint32_t);
 
     case amdgpu_regnum_t::scratch_base:
@@ -6871,6 +6885,11 @@ gfx12_architecture_t::register_read_only_mask (amdgpu_regnum_t regnum) const
       {
         static uint32_t excp_flag_user_ro_bits = utils::bit_mask (7, 29);
         return &excp_flag_user_ro_bits;
+      }
+    case amdgpu_regnum_t::sched_mode:
+      {
+        static uint32_t pseudo_sched_mode_ro_bits = utils::bit_mask (2,31);
+        return &pseudo_sched_mode_ro_bits;
       }
 
     case amdgpu_regnum_t::trapsts:
@@ -7087,6 +7106,15 @@ gfx12_architecture_t::cwsr_record_t::register_address (
 
     case amdgpu_regnum_t::status:
       regnum = amdgpu_regnum_t::first_hwreg + 13;
+      break;
+
+    case amdgpu_regnum_t::sched_mode:
+        {
+          if (!queue ().process ().os_driver ().save_sched_mode ())
+            return std::nullopt;
+
+          regnum = amdgpu_regnum_t::first_hwreg + 16;
+        }
       break;
 
     case amdgpu_regnum_t::trapsts:

--- a/src/os_driver.h
+++ b/src/os_driver.h
@@ -559,6 +559,11 @@ public:
   xfer_agent_memory_partial (os_agent_id_t agent, agent_address_t address,
                              void *read, const void *write, size_t *size) const
     = 0;
+
+  /* Helper to figure out if a given driver supports certain features.  */
+
+  /* Tells if the CWSR trap handler saves the SCHED_MODE register.  */
+  virtual bool save_sched_mode () const = 0;
 };
 
 /* OS driver class that implements no access that can be used if there is no
@@ -758,6 +763,11 @@ public:
     /* Suppress warnings in release builds.  */
     [] (auto &&...) {}(read, write);
     return AMD_DBGAPI_STATUS_ERROR_MEMORY_ACCESS;
+  }
+
+  bool save_sched_mode () const
+  {
+    return false;
   }
 };
 

--- a/src/os_driver_kfd.cpp
+++ b/src/os_driver_kfd.cpp
@@ -511,6 +511,13 @@ protected:
                                        write, size);
   }
 
+  bool save_sched_mode () const override
+  {
+    version_t kfd_ioctl_version = get_kfd_version ();
+
+    return kfd_ioctl_version >= version_t {1, 20};
+  }
+
 private:
   static std::string marketing_name (uint32_t vendor_id, uint32_t device_id,
                                      uint32_t revision_id);

--- a/src/register.h
+++ b/src/register.h
@@ -138,6 +138,7 @@ enum class amdgpu_regnum_t : uint32_t
   xnack_mask_64,      /* XNACK mask for wave64 wavefronts.  */
   flat_scratch,       /* Flat scratch.  */
   scratch_base = flat_scratch,
+  sched_mode,         /* Scheduling mode configuration.  */
 
   /* SHADER_CYCLES_LO / SHADER_CYCLES_HI / DVGPR_ALLOC_LO / DVGPR_ALLOC_HI ?*/
 


### PR DESCRIPTION
If driver saves SCHED_MODE in CWSR, show it as part of the system registers.

Change-Id: I77cd0fdcf9e83d2a2a8521ef915f4f094745b963