### PR TITLE
Add AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.78.0)
+project(amd-dbgapi VERSION 0.79.0)
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)

--- a/include/amd-dbgapi.h.in
+++ b/include/amd-dbgapi.h.in
@@ -625,10 +625,16 @@ extern "C" {
 #define AMD_DBGAPI_VERSION_0_77
 
 /**
- * The function was introduced in version 0.77 of the interface and has the
+ * The function was introduced in version 0.78 of the interface and has the
  * symbol version string of ``"@AMD_DBGAPI_NAME@_0.78"``.
  */
 #define AMD_DBGAPI_VERSION_0_78
+
+/**
+ * The function was introduced in version 0.79 of the interface and has the
+ * symbol version string of ``"@AMD_DBGAPI_NAME@_0.79"``.
+ */
+#define AMD_DBGAPI_VERSION_0_79
 
 /** @} */
 
@@ -1836,6 +1842,14 @@ typedef enum
    * ::AMD_DBGAPI_STATUS_ERROR_CLIENT_CALLBACK error.
    */
   AMD_DBGAPI_PROCESS_INFO_CORE_STATE = 7,
+  /**
+   * Return a bitmask of all the bits which are use in at least of one of
+   * the address spaces of each of the agents of the system.  It is legal for
+   * the client to not preserve bits not set in this mask, as long as they are
+   * cleared before being returned back to the library.  The type of this
+   * attribute is ::amd_dbgapi_segment_address_t.
+   */
+  AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS = 8,
 } amd_dbgapi_process_info_t;
 
 /**
@@ -1889,7 +1903,7 @@ typedef enum
  */
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_process_get_info (
     amd_dbgapi_process_id_t process_id, amd_dbgapi_process_info_t query,
-    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_77;
+    size_t value_size, void *value) AMD_DBGAPI_VERSION_0_79;
 
 /**
  * Attach to a process in order to provide debug control of the AMD GPUs it

--- a/src/exportmap.in
+++ b/src/exportmap.in
@@ -91,11 +91,14 @@ global: amd_dbgapi_displaced_stepping_complete;
 } @AMD_DBGAPI_NAME@_0.70;
 
 @AMD_DBGAPI_NAME@_0.77 {
-global: amd_dbgapi_process_get_info;
-        amd_dbgapi_set_alu_exceptions_precision;
+global: amd_dbgapi_set_alu_exceptions_precision;
 } @AMD_DBGAPI_NAME@_0.76;
 
 @AMD_DBGAPI_NAME@_0.78 {
 global: amd_dbgapi_read_memory;
         amd_dbgapi_write_memory;
 } @AMD_DBGAPI_NAME@_0.77;
+
+@AMD_DBGAPI_NAME@_0.79 {
+global: amd_dbgapi_process_get_info;
+} @AMD_DBGAPI_NAME@_0.78;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -621,6 +621,7 @@ to_string (amd_dbgapi_process_info_t process_info)
       CASE (PROCESS_INFO_OS_ID);
       CASE (PROCESS_INFO_CORE_STATE);
       CASE (PROCESS_INFO_PRECISE_ALU_EXCEPTIONS_SUPPORTED);
+      CASE (PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS);
     }
   return to_string (make_hex (process_info));
 }
@@ -652,6 +653,9 @@ to_string (detail::query_ref<amd_dbgapi_process_info_t> ref)
     case AMD_DBGAPI_PROCESS_INFO_PRECISE_ALU_EXCEPTIONS_SUPPORTED:
       return to_string (make_ref (
         static_cast<const amd_dbgapi_alu_exceptions_precision_t *> (value)));
+    case AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS:
+      return to_string (
+        make_ref (static_cast<const amd_dbgapi_segment_address_t *> (value)));
     }
   fatal_error ("unhandled amd_dbgapi_process_info_t query (%s)",
                to_cstring (query));

--- a/src/os_driver.cpp
+++ b/src/os_driver.cpp
@@ -173,13 +173,14 @@ to_string (os_agent_info_t os_agent_info)
     ".gfxip=[%d,%d,%d], .simd_count=%zd, .max_waves_per_simd=%zd, "
     ".shader_engine_count=%zd, .vendor_id=%#x, .device_id=%#x, "
     ".revision_id=%#x, .subsystem_vendor_id=%#x, .subsystem_device_id=%#x, "
-    ".fw_version=%d, .local_address_aperture_base=%s, "
-    ".local_address_aperture_limit=%s, .private_address_aperture_base=%s, "
-    ".private_address_aperture_limit=%s, .debugging_supported=%d, "
-    ".address_watch_supported=%d, .address_watch_register_count=%zd, "
-    ".address_watch_mask_bits=%#" PRIx64 ", .watchpoint_exclusive=%d, "
-    ".precise_memory_supported=%d, .precise_alu_exceptions_supported=%d,"
-    ".firmware_supported=%d, ttmps_always_initialized=%d }",
+    ".fw_version=%d, .agent_address_base=%s, .agent_address_limit=%s,"
+    " .local_address_aperture_base=%s, .local_address_aperture_limit=%s, "
+    ".private_address_aperture_base=%s, .private_address_aperture_limit=%s, "
+    ".debugging_supported=%d, .address_watch_supported=%d, "
+    ".address_watch_register_count=%zd, .address_watch_mask_bits=%#" PRIx64
+    ", .watchpoint_exclusive=%d, .precise_memory_supported=%d, "
+    ".precise_alu_exceptions_supported=%d, .firmware_supported=%d, "
+    "ttmps_always_initialized=%d }",
     os_agent_info.os_agent_id, os_agent_info.name.c_str (),
     os_agent_info.domain, os_agent_info.location_id, os_agent_info.gfxip[0],
     os_agent_info.gfxip[1], os_agent_info.gfxip[2], os_agent_info.simd_count,
@@ -187,6 +188,8 @@ to_string (os_agent_info_t os_agent_info)
     os_agent_info.vendor_id, os_agent_info.device_id,
     os_agent_info.revision_id, os_agent_info.subsystem_vendor_id,
     os_agent_info.subsystem_device_id, os_agent_info.fw_version,
+    to_cstring (os_agent_info.agent_address_base),
+    to_cstring (os_agent_info.agent_address_limit),
     to_cstring (os_agent_info.local_address_aperture_base),
     to_cstring (os_agent_info.local_address_aperture_limit),
     to_cstring (os_agent_info.private_address_aperture_base),

--- a/src/os_driver.h
+++ b/src/os_driver.h
@@ -107,6 +107,10 @@ struct os_agent_info_t
   uint32_t subsystem_device_id{ 0 };
   /* ucode version.  */
   uint32_t fw_version{ 0 };
+  /* Agent address base.  */
+  agent_address_t agent_address_base{ 0 };
+  /* Agent address limit.  */
+  agent_address_t agent_address_limit{ 0 };
   /* local/shared address aperture base.  */
   agent_address_t local_address_aperture_base{ 0 };
   /* local/shared address aperture limit.  */

--- a/src/os_driver_kfd.cpp
+++ b/src/os_driver_kfd.cpp
@@ -659,6 +659,8 @@ kfd_driver_base_t::agent_snapshot (
 
       agent_info.os_agent_id = entry.gpu_id;
 
+      agent_info.agent_address_base = entry.gpuvm_base;
+      agent_info.agent_address_limit = entry.gpuvm_limit;
       agent_info.local_address_aperture_base = entry.lds_base;
       agent_info.local_address_aperture_limit = entry.lds_limit;
       agent_info.private_address_aperture_base = entry.scratch_base;

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -1756,6 +1756,25 @@ process_t::get_info (amd_dbgapi_process_info_t query, size_t value_size,
                          ? AMD_DBGAPI_ALU_EXCEPTIONS_PRECISION_PRECISE
                          : AMD_DBGAPI_ALU_EXCEPTIONS_PRECISION_NONE);
       return;
+
+    case AMD_DBGAPI_PROCESS_INFO_SIGNIFICANT_ADDRESS_BITS:
+      {
+        if (value_size != sizeof (amd_dbgapi_segment_address_t))
+          throw api_error_t (
+            AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT_COMPATIBILITY);
+
+        amd_dbgapi_segment_address_t val = 0;
+
+        for (auto &&agent : range<agent_t> ())
+          {
+            val |= agent.os_info ().local_address_aperture_limit
+                   | agent.os_info ().private_address_aperture_limit
+                   | agent.os_info ().agent_address_limit;
+          }
+
+        *static_cast<amd_dbgapi_segment_address_t *> (value) = val;
+        return;
+      }
     }
 
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ARGUMENT);


### PR DESCRIPTION
Add a new per-process query to find buts used across all the address-spaces.  This is intended to be used by the client to know which bits of an address can be used to carry extra information.

Bug: AIROCGDB-26
Change-Id: I523ffef506fd8d2fe1400075e9501ad5f16a54aa